### PR TITLE
Add instructions for overriding `buildInput` and agent id environment variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,13 +13,13 @@ OPENSEARCH_USERNAME=admin
 OPENSEARCH_PASSWORD=admin
 
 # API provider to use for testing. options: olly_chat or agent_framework
-API_PROVIDER=olly_chat
+API_PROVIDER=agent_framework
 
 # Agents, required if API_PROVIDER is agent_framework
 ROOT_AGENT_ID=
 PPL_AGENT_ID=
 
-# Evaluation models, required if LLM or embeddings based test evaluations are used. fallbacks to reading `.chat-assistant-config` if not provided 
+# Evaluation models, required if LLM or embeddings based test evaluations are used. fallbacks to reading `.chat-assistant-config` if not provided
 # ml-commons model id for LLM based requests
 ML_COMMONS_LLM_ID=
 # ml-commons model id for embeddings based requests

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prepare": "husky install",
     "lint": "eslint --fix .",
     "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 ts-node src/index.ts",
-    "postinstall": "find ./packages -name requirements.txt -type f -execdir sh -c '[ ! -d venv ] && python3 -m venv venv; source venv/bin/activate; pip install -r {}' \\;"
+    "postinstall": "find ./packages -name requirements.txt -type f -execdir sh -c '[ ! -d venv ] && python3 -m venv venv; . venv/bin/activate; pip install -r {}' \\;"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/src/providers/factory/index.ts
+++ b/src/providers/factory/index.ts
@@ -29,7 +29,7 @@ export class ApiProviderFactory {
         return new MlCommonsApiProvider();
 
       case PROVIDERS.AGENT_FRAMEWORK:
-        return new AgentFrameworkApiProvider();
+        return new AgentFrameworkApiProvider(undefined, options.agentIdKey);
 
       default:
         console.info(`$API_PROVIDER unset or invalid, defaulting to ${PROVIDERS.OLLY} provider`);

--- a/src/providers/ml_commons/agent_framework.ts
+++ b/src/providers/ml_commons/agent_framework.ts
@@ -43,7 +43,7 @@ export class AgentFrameworkApiProvider implements ApiProvider {
   }
 
   async callApi(
-    prompt: string,
+    prompt?: string,
     context?: { vars: Record<string, string | object> },
   ): Promise<OpenSearchProviderResponse> {
     try {

--- a/src/providers/ml_commons/agent_framework.ts
+++ b/src/providers/ml_commons/agent_framework.ts
@@ -54,10 +54,10 @@ export class AgentFrameworkApiProvider implements ApiProvider {
         body: JSON.stringify({ parameters: { question: prompt, ...context?.vars } }),
       })) as ApiResponse<AgentResponse, unknown>;
 
-      const output = getValue(response.body, [
-        'inference_results[0].output[0].dataAsMap.response',
-        'inference_results[0].output[0].result',
-      ]);
+      const outputResponse =
+        response.body.inference_results[0].output.find((output) => output.name === 'response') ??
+        response.body.inference_results[0].output[0];
+      const output = getValue(outputResponse, ['dataAsMap.response', 'result']);
       if (!output) throw new Error('Cannot find output from agent response');
       return { output, extras: { rawResponse: response.body } };
     } catch (error) {

--- a/src/runners/qa/qa_runner.ts
+++ b/src/runners/qa/qa_runner.ts
@@ -18,18 +18,10 @@ export class QARunner extends TestRunner<QASpec, ApiProvider> {
     console.info(
       `Received: ${received.output}\nExpected: ${spec.expectedAnswer}\nScore: ${result.score}\n`,
     );
-    try {
-      return Promise.resolve({
-        pass: result.pass,
-        message: () => result.reason,
-        score: result.score,
-      });
-    } catch (error) {
-      return Promise.resolve({
-        pass: false,
-        message: () => `failed to execture ${String(error)}`,
-        score: 0,
-      });
-    }
+    return Promise.resolve({
+      pass: result.pass,
+      message: () => result.reason,
+      score: result.score,
+    });
   }
 }

--- a/src/runners/qa/qa_runner.ts
+++ b/src/runners/qa/qa_runner.ts
@@ -16,7 +16,7 @@ export class QARunner extends TestRunner<QASpec, ApiProvider> {
   public async evaluate(received: OpenSearchProviderResponse, spec: QASpec): Promise<TestResult> {
     const result = await matchesFactuality(spec.question, received.output!, spec.expectedAnswer);
     console.info(
-      `Received: ${received.output}\nExpected: ${spec.expectedAnswer}\nScore: ${result.score}\n`,
+      `Question: ${spec.question}\nReceived: ${received.output}\nExpected: ${spec.expectedAnswer}\nScore: ${result.score}\n`,
     );
     return Promise.resolve({
       pass: result.pass,

--- a/src/runners/query/ppl_runner.ts
+++ b/src/runners/query/ppl_runner.ts
@@ -110,7 +110,7 @@ export class PPLRunner extends TestRunner<PPLSpec, ApiProvider> {
         )
       ).score;
       console.info(
-        `Received PPL: ${ppl}\nExpected query: ${spec.gold_query}\nScore: ${evalResult.score}`,
+        `Question: ${spec.question}\nReceived PPL: ${ppl}\nExpected query: ${spec.gold_query}\nScore: ${evalResult.score}`,
       );
       return {
         pass: evalResult.score >= 0.8,

--- a/src/runners/test_runner.ts
+++ b/src/runners/test_runner.ts
@@ -10,6 +10,7 @@ import fs from 'fs';
 import fsPromises from 'node:fs/promises';
 import path from 'path';
 import { addMsg } from 'jest-html-reporters/helper';
+import _ from 'lodash';
 import { ApiProvider } from 'promptfoo';
 
 export interface TestSpec {
@@ -222,6 +223,7 @@ export abstract class TestRunner<
       extras: result.extras,
       executed_at: Date.now(),
       execution_ms: executionMs,
+      ..._.omit(spec, 'id'),
     };
   }
 

--- a/src/runners/test_runner.ts
+++ b/src/runners/test_runner.ts
@@ -76,10 +76,15 @@ export abstract class TestRunner<
    * @param spec test case
    * @returns prompt and context
    */
-  protected buildInput(spec: T): {
-    prompt: Parameters<ApiProvider['callApi']>[0];
-    context: Parameters<ApiProvider['callApi']>[1];
-  } {
+  protected buildInput(spec: T):
+    | {
+        prompt: Parameters<ApiProvider['callApi']>[0];
+        context: Parameters<ApiProvider['callApi']>[1];
+      }
+    | {
+        prompt?: Parameters<ApiProvider['callApi']>[0];
+        context: NonNullable<Parameters<ApiProvider['callApi']>[1]>;
+      } {
     return {
       prompt: spec.question,
       context: undefined,
@@ -106,6 +111,10 @@ export abstract class TestRunner<
    */
   private async runSpec(spec: T): Promise<ReturnType<U['callApi']>> {
     const input = this.buildInput(spec);
+    // @ts-expect-error promptfoo requires a prompt string to be passed to
+    // callApi, but agent framework only expects a parameters object. `prompt`
+    // will be passed as the `question` key in the parameters object and can be
+    // undefined.
     const received = (await this.apiProvider.callApi(input.prompt, input.context)) as Awaited<
       ReturnType<U['callApi']>
     >;


### PR DESCRIPTION
### Description
Add instructions for overriding `buildInput` and agent id environment variable
Improve logging

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
