### PR TITLE
(agent framework provider) look for response instead of first key

### DIFF
--- a/src/providers/ml_commons/agent_framework.ts
+++ b/src/providers/ml_commons/agent_framework.ts
@@ -54,10 +54,10 @@ export class AgentFrameworkApiProvider implements ApiProvider {
         body: JSON.stringify({ parameters: { question: prompt, ...context?.vars } }),
       })) as ApiResponse<AgentResponse, unknown>;
 
-      const output = getValue(response.body, [
-        'inference_results[0].output[0].dataAsMap.response',
-        'inference_results[0].output[0].result',
-      ]);
+      const outputResponse =
+        response.body.inference_results[0].output.find((output) => output.name === 'response') ??
+        response.body.inference_results[0].output[0];
+      const output = getValue(outputResponse, ['dataAsMap.response', 'result']);
       if (!output) throw new Error('Cannot find output from agent response');
       return { output, extras: { rawResponse: response.body } };
     } catch (error) {


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>
(cherry picked from commit 6a1381db018fdabb11b9fe982fa9387718b0fe09)

### Description
The response of agent execution could contain other information, this PR will make it to read output from a `name === response` object if it exists

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
