### PR TITLE
Pin python dependencies to enforce version resolution

### DIFF
--- a/packages/bert/requirements.txt
+++ b/packages/bert/requirements.txt
@@ -1,3 +1,3 @@
 bert_score==0.3.13
-pillow>=12.1.1
-torch>=2.10.0
+pillow==12.1.1
+torch==2.10.0


### PR DESCRIPTION
### Description

In #100, I added minimum version constraints for transitive dependencies of bert.  Unfortunately, with the current configuration, Mend did not perform a full dependency resolution and flagged the older (transitive) versions even though the newer versions were specified with a `>=` constraint.

This PR changes those minimum version constraints to pinned actual versions.
### Issues Resolved

I expect when merged, Mend will auto-close issue #102 (Critical) and edit #101 to remove the resolved "High" CVEs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
